### PR TITLE
Update database config to allow using Redis via Unix sockets

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -132,6 +132,8 @@ return [
             'password' => env('REDIS_PASSWORD', null),
             'port' => env('REDIS_PORT', '6379'),
             'database' => env('REDIS_DB', '0'),
+            'scheme' => env('REDIS_SCHEME', 'tcp'),
+            'path' => env('REDIS_PATH', null),
         ],
 
         'cache' => [
@@ -140,6 +142,8 @@ return [
             'password' => env('REDIS_PASSWORD', null),
             'port' => env('REDIS_PORT', '6379'),
             'database' => env('REDIS_CACHE_DB', '1'),
+            'scheme' => env('REDIS_SCHEME', 'tcp'),
+            'path' => env('REDIS_PATH', null),
         ],
 
     ],


### PR DESCRIPTION
This change allows Redis to be used via Unix sockets instead of TCP. I don't believe the application uses Redis directly, but I am using it as the session driver.