### PR TITLE
add ASSET_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 APP_NAME=Envault
 APP_KEY=
 APP_URL=http://localhost
+ASSET_URL=http://localhost
 
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1


### PR DESCRIPTION
Somehow, if the ASSET_URL is not present, the assets are retrieved from "http", even if you've set APP_URL with "https"